### PR TITLE
fix flush command by removing forgotten line

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -2327,7 +2327,6 @@ class SimpleContextPlugin {
     else if (this.banCommands.includes(cmd)) this.banEntry(params)
     else if (this.killCommands.includes(cmd)) this.setEntryStatus(params, SC_STATUS.DEAD)
     else if (this.reviveCommands.includes(cmd)) this.setEntryStatus(params, SC_STATUS.ALIVE)
-    else if (this.updateCommands.includes(cmd)) this.updatePlugin(!cmd.endsWith("!"))
     else if (this.flushCommands.includes(cmd)) {
       state.displayStats = []
       if (cmd.endsWith("!")) this.reloadPlugin()


### PR DESCRIPTION
Seems like the updates plugin was removed but there was an if looking for it and was preventing the execution of the flush command because it didn't exist anymore.

I simply removed that line